### PR TITLE
Custom cipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ assert(deciphered == source)
 
 ### Other implementations
 
-For those interested, I also made another implementation this Feistel cipher in [Golang](https://github.com/cyrildever/feistel).
+For those interested, I also made another implementation of this Feistel cipher in [Golang](https://github.com/cyrildever/feistel).
 
 
 ### License

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There is no restriction on the ![$F$](https://render.githubusercontent.com/rende
 npm i feistel-cipher
 ```
 
-To get an obfuscated string from a source data, first instantiate a `Cipher` object, passing it a key and a number of rounds.
+To get an obfuscated string from a source data using the SHA-256 hashing function at each round, first instantiate a `Cipher` object, passing it a key and a number of rounds.
 Then, use the `encrypt()` method with the source data as argument. The result will be a `Buffer`.
 To ensure maximum security, I recommend you use a 256-bit key or longer and a minimum of 10 rounds.
 
@@ -59,6 +59,16 @@ const obfuscated = cipher.encrypt(source)
 const deciphered = cipher.decrypt(obfuscated)
 
 assert(deciphered == source)
+```
+_NB: This is the same default behaviour as in my Golang implementation (see below)._
+
+You may also want to use your own set of keys with `CustomCipher` and a number of rounds depending on the number of provided keys, eg.
+```typescript
+const cipher = new feistel.CustomCipher([
+  '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  '9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba',
+  'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+])
 ```
 
 

--- a/lib/src/typescript/feistel.ts
+++ b/lib/src/typescript/feistel.ts
@@ -20,14 +20,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import { createHash, BinaryLike } from 'crypto'
-
-const sha256 = (msg: BinaryLike): Buffer =>
-  createHash('sha256').update(msg).digest()
+import { Hash } from './utils/hash'
+import { PADDING_CHARACTER, unpad } from './utils/padding'
+import { add, extract, split } from './utils/strings'
+import { xor } from './utils/xor'
 
 /**
- * The Cipher class is the main entry point to the Feistel cipher.
- * You should instantiate it with the key you want to use and the number of rounds to apply.
+ * The Cipher class is the main entry point to the Feistel cipher if you want to use the SHA-256 hash function at each round.
+ * You should instantiate it with the base key you want to use and the number of rounds to apply.
  * For better security, you should choose a 256-bit key or longer, and 10 rounds is a good start.
  * Once instantiated, use the apply() or unapply() methods on the Cipher instance with the appropriate data.
  */
@@ -51,9 +51,9 @@ export class Cipher {
       data = data.padStart(data.length + 1, PADDING_CHARACTER)
     }
     // Apply the Feistel cipher
-    let parts = this.split(data)
+    let parts = split(data)
     for (let i = 0; i < this.rounds; ++i) { // eslint-disable-line no-loops/no-loops
-      const tmp = this.xor(parts[0], this.round(parts[1], i))
+      const tmp = xor(parts[0], this.round(parts[1], i))
       parts = [parts[1], tmp]
     }
     return Buffer.from(parts[0] + parts[1])
@@ -71,11 +71,11 @@ export class Cipher {
       throw new Error('invalid obfuscated data')
     }
     // Apply Feistel cipher
-    const parts = this.split(o)
+    const parts = split(o)
     let a = parts[1]
     let b = parts[0]
     for (let i = 0; i < this.rounds; ++i) { // eslint-disable-line no-loops/no-loops
-      const tmp = this.xor(a, this.round(b, this.rounds - i - 1))
+      const tmp = xor(a, this.round(b, this.rounds - i - 1))
       a = b
       b = tmp
     }
@@ -84,52 +84,10 @@ export class Cipher {
 
   // Feistel implementation
 
-  // Add adds two strings in the sense that each charCode are added
-  private add(str1: string, str2: string): string {
-    if (str1.length != str2.length) {
-      throw new Error('to be added, strings must be of the same length')
-    }
-    return Array.from(str1).reduce((addedString, c, idx) => addedString + String.fromCharCode(c.charCodeAt(0) + str2.charCodeAt(idx)), '')
-  }
-
-  // Extract returns an extraction of the passed string of the desired length from the passed start index.
-  // If the desired length is too long, the key string is repeated.
-  private extract(from: string, startIndex: number, desiredLength: number): string {
-    startIndex = startIndex % from.length
-    const lengthNeeded = startIndex + desiredLength
-    return from.repeat(Math.ceil(lengthNeeded / from.length)).substr(startIndex, desiredLength)
-  }
-
   // Round is the function applied at each round of the obfuscation process to the right side of the Feistel cipher
   private round(item: string, index: number): string {
-    const addition = this.add(item, this.extract(this.key, index, item.length))
-    const hashed = sha256(addition).toString('hex')
-    return this.extract(hashed, index, item.length)
+    const addition = add(item, extract(this.key, index, item.length))
+    const hashed = Hash(addition).toString('hex')
+    return extract(hashed, index, item.length)
   }
-
-  // Split splits a string in two equal parts
-  private split(str: string): [string, string] {
-    if (str.length % 2 != 0) {
-      throw new Error('invalid string length: cannot be split')
-    }
-    const half = str.length / 2
-    return [str.substr(0, half), str.substr(half)]
-  }
-
-  // Xor function XOR two strings in the sense that each charCode are xored
-  private xor(str1: string, str2: string): string {
-    return Array.from(str1).reduce((xored, c, idx) => xored + String.fromCharCode(c.charCodeAt(0) ^ str2.charCodeAt(idx)), '')
-  }
-}
-
-//--- PADDING utilities
-
-// Unicode U+0002: start of text
-const PADDING_CHARACTER = '\u0002'
-
-const unpad = (str: string): string => {
-  while (str.startsWith(PADDING_CHARACTER)) { // eslint-disable-line no-loops/no-loops
-    str = str.substr(1)
-  }
-  return str
 }

--- a/lib/src/typescript/index.ts
+++ b/lib/src/typescript/index.ts
@@ -21,3 +21,4 @@ SOFTWARE.
 */
 
 export * from './feistel'
+export * from './custom'

--- a/lib/src/typescript/utils/hash.ts
+++ b/lib/src/typescript/utils/hash.ts
@@ -1,0 +1,26 @@
+/*
+MIT License
+
+Copyright (c) 2020 Cyril Dever
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import { createHash, BinaryLike } from 'crypto'
+
+export const Hash = (msg: BinaryLike): Buffer =>
+  createHash('sha256').update(msg).digest()

--- a/lib/src/typescript/utils/padding.ts
+++ b/lib/src/typescript/utils/padding.ts
@@ -1,0 +1,31 @@
+/*
+MIT License
+
+Copyright (c) 2020 Cyril Dever
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// Unicode U+0002: start-of-text
+export const PADDING_CHARACTER = '\u0002'
+
+export const unpad = (str: string): string => {
+  while (str.startsWith(PADDING_CHARACTER)) { // eslint-disable-line no-loops/no-loops
+    str = str.substr(1)
+  }
+  return str
+}

--- a/lib/src/typescript/utils/strings.ts
+++ b/lib/src/typescript/utils/strings.ts
@@ -1,0 +1,46 @@
+/*
+MIT License
+
+Copyright (c) 2020 Cyril Dever
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// Adds two strings in the sense that each charCode are added
+export const add = (str1: string, str2: string): string => {
+  if (str1.length != str2.length) {
+    throw new Error('to be added, strings must be of the same length')
+  }
+  return Array.from(str1).reduce((addedString, c, idx) => addedString + String.fromCharCode(c.charCodeAt(0) + str2.charCodeAt(idx)), '')
+}
+
+// Returns an extraction of the passed string of the desired length from the passed start index.
+// If the desired length is too long, the key string is repeated.
+export const extract = (from: string, startIndex: number, desiredLength: number): string => {
+  startIndex = startIndex % from.length
+  const lengthNeeded = startIndex + desiredLength
+  return from.repeat(Math.ceil(lengthNeeded / from.length)).substr(startIndex, desiredLength)
+}
+
+// Splits a string in two equal parts
+export const split = (str: string): [string, string] => {
+  if (str.length % 2 != 0) {
+    throw new Error('invalid string length: cannot be split')
+  }
+  const half = str.length / 2
+  return [str.substr(0, half), str.substr(half)]
+}

--- a/lib/src/typescript/utils/xor.ts
+++ b/lib/src/typescript/utils/xor.ts
@@ -1,0 +1,26 @@
+/*
+MIT License
+
+Copyright (c) 2020 Cyril Dever
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// xor applies XOR operation on two strings in the sense that each charCode are xored
+export const xor = (str1: string, str2: string): string => {
+  return Array.from(str1).reduce((xored, c, idx) => xored + String.fromCharCode(c.charCodeAt(0) ^ str2.charCodeAt(idx)), '')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "feistel-cipher",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feistel-cipher",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Feistel cipher implementation for (almost) format-preserving encryption",
   "main": "dist/lib/src/typescript/index.js",
   "types": "dist/lib/src/typescript/index.d.ts",
@@ -8,7 +8,8 @@
     "compile": "eslint lib --ext .ts && tsc",
     "fix": "eslint lib --ext .ts --fix",
     "test": "tsc && mocha 'test/src/typescript/node.spec.ts' --require ts-node/register && browserify ./dist/test/src/typescript/browser.spec.js -o dist/test/src/typescript/index.js && live-server --port=9001 --mount=/:test/src/typescript",
-    "fix-test": "eslint test --ext .ts --fix"
+    "fix-test": "eslint test --ext .ts --fix",
+    "test-node": "tsc && mocha 'test/src/typescript/node.spec.ts' --require ts-node/register"
   },
   "repository": {
     "type": "git",

--- a/test/src/typescript/browser.spec.ts
+++ b/test/src/typescript/browser.spec.ts
@@ -1,7 +1,7 @@
 import * as feistel from '../../../lib/src/typescript/index'
 
 describe('Cipher', () => {
-  describe('apply', () => {
+  describe('encrypt', () => {
     it('should be deterministic', () => {
       const cipher = new feistel.Cipher('8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692', 10)
       const found = cipher.encrypt('Edgewhere')
@@ -10,10 +10,57 @@ describe('Cipher', () => {
       found.toString('hex').should.equal(expected)
     })
   })
-  describe('unapply', () => {
+  describe('decrypt', () => {
     it('should be deterministic', () => {
       const cipher = new feistel.Cipher('8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692', 10)
       const found = cipher.decrypt(Buffer.from('3d7c0a0f51415a521054', 'hex'))
+
+      const expected = 'Edgewhere'
+      found.should.equal(expected)
+    })
+  })
+})
+describe('CustomCipher', () => {
+  describe('encrypt', () => {
+    it('should be deterministic', () => {
+      // Identical to Cipher.encrypt test above
+      let cipher = new feistel.CustomCipher([
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692'
+      ])
+      let found = cipher.encrypt('Edgewhere')
+
+      let expected = '3d7c0a0f51415a521054'
+      found.toString('hex').should.equal(expected)
+
+      // Another test with different custom keys
+      cipher = new feistel.CustomCipher([
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        '9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba',
+        'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+      ])
+      found = cipher.encrypt('Edgewhere')
+
+      expected = '445951465c5a19613633'
+      found.toString('hex').should.equal(expected)
+    })
+  })
+  describe('decrypt', () => {
+    it('should be deterministic', () => {
+      const cipher = new feistel.CustomCipher([
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        '9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba',
+        'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+      ])
+      const found = cipher.decrypt(Buffer.from('445951465c5a19613633', 'hex'))
 
       const expected = 'Edgewhere'
       found.should.equal(expected)

--- a/test/src/typescript/node.spec.ts
+++ b/test/src/typescript/node.spec.ts
@@ -5,7 +5,7 @@ chai.should()
 import * as feistel from '../../../lib/src/typescript/index'
 
 describe('Cipher', () => {
-  describe('apply', () => {
+  describe('encrypt', () => {
     it('should be deterministic', () => {
       const cipher = new feistel.Cipher('8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692', 10)
       const found = cipher.encrypt('Edgewhere')
@@ -14,10 +14,57 @@ describe('Cipher', () => {
       found.toString('hex').should.equal(expected)
     })
   })
-  describe('unapply', () => {
+  describe('decrypt', () => {
     it('should be deterministic', () => {
       const cipher = new feistel.Cipher('8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692', 10)
       const found = cipher.decrypt(Buffer.from('3d7c0a0f51415a521054', 'hex'))
+
+      const expected = 'Edgewhere'
+      found.should.equal(expected)
+    })
+  })
+})
+describe('CustomCipher', () => {
+  describe('encrypt', () => {
+    it('should be deterministic', () => {
+      // Identical to Cipher.encrypt test above
+      let cipher = new feistel.CustomCipher([
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692',
+        '8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692'
+      ])
+      let found = cipher.encrypt('Edgewhere')
+
+      let expected = '3d7c0a0f51415a521054'
+      found.toString('hex').should.equal(expected)
+
+      // Another test with different custom keys
+      cipher = new feistel.CustomCipher([
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        '9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba',
+        'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+      ])
+      found = cipher.encrypt('Edgewhere')
+
+      expected = '445951465c5a19613633'
+      found.toString('hex').should.equal(expected)
+    })
+  })
+  describe('decrypt', () => {
+    it('should be deterministic', () => {
+      const cipher = new feistel.CustomCipher([
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        '9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba',
+        'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+      ])
+      const found = cipher.decrypt(Buffer.from('445951465c5a19613633', 'hex'))
 
       const expected = 'Edgewhere'
       found.should.equal(expected)


### PR DESCRIPTION
Add custom cipher to provide it with a set of own keys (instead of using only the SHA-256 hash function at each round).
The latter behaviour remains the default one.