### PR TITLE
Keep integer as integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ const obfuscatedNumber = cipher.encryptNumber(sourceNumber)
 const deobfuscatedNumber = cipher.decryptNumber(obfuscatedNumber)
 assert(sourceNumber == deobfuscatedNumber)
 ```
+_NB: For stability and security purposes, the number `0` always returns itself._
 
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ assert(obfuscated.length, source.length)
 If you want to use FPE for numbers, you might want to use the `encryptNumber()` method on the `FPECipher` which will return a number that you may pad if need be to match your requirements:
 ```typescript
 const obfuscatedNumber = cipher.encryptNumber(sourceNumber)
+const deobfuscatedNumber = cipher.decryptNumber(obfuscatedNumber)
+assert(sourceNumber == deobfuscatedNumber)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ const obfuscated = cipher.encrypt(source)
 assert(obfuscated.length, source.length)
 ```
 
+If you want to use FPE for numbers, you might want to use the `encryptNumber()` method on the `FPECipher` which will return a number that you may pad if need be to match your requirements:
+```typescript
+const obfuscatedNumber = cipher.encryptNumber(sourceNumber)
+```
+
+
 ### Dependencies
 
 This library relies on three peer dependencies:

--- a/lib/src/typescript/fpe.ts
+++ b/lib/src/typescript/fpe.ts
@@ -87,6 +87,11 @@ export class FPECipher {
    * @returns {number} The obfuscated number.
    */
   encryptNumber(n: number): number {
+    if (n < 256) {
+      const buf = Buffer.alloc(2)
+      buf.writeUInt16BE(n)
+      return readable2Buffer(this.encrypt(buf.toString())).readUInt16BE()
+    }
     let buf = Buffer.alloc(4)
     buf.writeUInt32BE(n)
     let parts = splitBytes(buf)

--- a/lib/src/typescript/fpe.ts
+++ b/lib/src/typescript/fpe.ts
@@ -88,7 +88,7 @@ export class FPECipher {
    */
   encryptNumber(n: number): number {
     let buf = Buffer.alloc(4)
-    buf.writeUint32BE(n)
+    buf.writeUInt32BE(n)
     let parts = splitBytes(buf)
     // Apply the FPE Feistel cipher
     for (let i = 0; i < this.rounds; ++i) { // eslint-disable-line no-loops/no-loops
@@ -110,7 +110,7 @@ export class FPECipher {
       parts = [left, right]
     }
     buf = Buffer.concat([parts[0], parts[1]])
-    return buf.readUint32BE()
+    return buf.readUInt32BE()
   }
 
   /**

--- a/lib/src/typescript/fpe.ts
+++ b/lib/src/typescript/fpe.ts
@@ -88,6 +88,9 @@ export class FPECipher {
    */
   encryptNumber(n: number): number {
     if (n < 256) {
+      if (n === 0) {
+        return 0
+      }
       const buf = Buffer.alloc(2)
       buf.writeUInt16BE(n)
       return readable2Buffer(this.encrypt(buf.toString())).readUInt16BE()
@@ -175,6 +178,9 @@ export class FPECipher {
    * @returns {number} The deobfuscated number.
    */
   decryptNumber(obfuscated: number): number {
+    if (obfuscated === 0) {
+      return 0
+    }
     let buf = Buffer.alloc(2)
     let short = true
     try {

--- a/lib/src/typescript/index.ts
+++ b/lib/src/typescript/index.ts
@@ -20,6 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+if (typeof window !== 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-var-requires
+  window.Buffer = window.Buffer || require('buffer').Buffer
+}
+
 export * from './feistel'
 export * from './fpe'
 export * from './custom'

--- a/lib/src/typescript/utils/bytes.ts
+++ b/lib/src/typescript/utils/bytes.ts
@@ -1,0 +1,58 @@
+/*
+MIT License
+
+Copyright (c) 2022 Cyril Dever
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// Adds two byte arrays in the sense that each bit values are added modulo 256 to be rendered as UTF-8
+export const addBytes = (bytes1: Buffer, bytes2: Buffer): Buffer => {
+  if (bytes1.length != bytes2.length) {
+    throw new Error('to be added, buffers must be of the same length')
+  }
+  return Buffer.from(bytes1).reduce((addedBuffer, c, idx) => {
+    return Buffer.concat([addedBuffer, bitValueToUtf8Bytes((c + bytes2[idx]) % 256)])
+  }, Buffer.alloc(0))
+}
+
+// Utility to mimic transformation of byte array to UTF-8 in Golang
+const bitValueToUtf8Bytes = (value: number): Buffer =>
+  value < 128
+    ? Buffer.from([value])
+    : value < 192
+      ? Buffer.from([194, value])
+      : Buffer.from([195, value - 64])
+
+// Returns an extraction of the passed byte array of the desired length from the passed start index.
+// If the desired length is too long, the key is repeated.
+export const extractBytes = (from: Buffer, startIndex: number, desiredLength: number): Buffer => {
+  startIndex = startIndex % from.length
+  const buf = Buffer.alloc(desiredLength)
+  const firstPart = from.slice(startIndex)
+  buf.fill(firstPart, 0, Math.min(firstPart.length, desiredLength), 'binary')
+  if (firstPart.length < desiredLength) {
+    buf.fill(from.toString('binary'), firstPart.length, undefined, 'binary')
+  }
+  return buf
+}
+
+// Splits a byte array in two parts
+export const splitBytes = (data: Buffer): [Buffer, Buffer] => {
+  const half = data.length / 2
+  return [data.slice(0, half), data.slice(half)]
+}

--- a/lib/src/typescript/utils/xor.ts
+++ b/lib/src/typescript/utils/xor.ts
@@ -25,4 +25,10 @@ export const xor = (str1: string, str2: string): string => {
   return Array.from(str1).reduce((xored, c, idx) => xored + String.fromCharCode(c.charCodeAt(0) ^ str2.charCodeAt(idx)), '')
 }
 
+// xorBytes applies XOR operation on thow byte arrays in the sense that each bit value are xored
+export const xorBytes = (bytes1: Buffer, bytes2: Buffer): Buffer => {
+  return Buffer.from(bytes1).reduce((xored, c, idx) => Buffer.concat([xored, Buffer.from([c ^ bytes2[idx]])]), Buffer.alloc(0))
+}
+
 export const NEUTRAL_BYTE = Buffer.from([0]).toString()
+export const NEUTRAL = Buffer.from([0])

--- a/package-lock.json
+++ b/package-lock.json
@@ -3721,10 +3721,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -7256,9 +7259,9 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
       "dev": true
     },
     "side-channel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,30 +1,30 @@
 {
   "name": "feistel-cipher",
-  "version": "1.3.14",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "feistel-cipher",
-      "version": "1.3.14",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.3",
         "@types/keccak": "^3.0.1",
-        "@types/mocha": "^9.1.1",
-        "@types/node": "^18.7.15",
-        "@typescript-eslint/eslint-plugin": "^5.36.2",
-        "@typescript-eslint/parser": "^5.36.2",
+        "@types/mocha": "^10.0.0",
+        "@types/node": "^18.8.5",
+        "@typescript-eslint/eslint-plugin": "^5.40.0",
+        "@typescript-eslint/parser": "^5.40.0",
         "blakejs": "^1.2.1",
         "browserify": "17.0.0",
         "chai": "^4.3.6",
-        "eslint": "^8.23.0",
+        "eslint": "^8.25.0",
         "eslint-plugin-no-loops": "~0.3.0",
         "keccak": "^3.0.2",
         "mocha": "^10.0.0",
         "sha3": "^2.1.4",
         "ts-node": "^10.9.1",
-        "typescript": "^4.8.2"
+        "typescript": "^4.8.4"
       },
       "peerDependencies": {
         "blakejs": "^1.2.1",
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -79,16 +79,6 @@
       },
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -216,28 +206,27 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-rADY+HtTOA52l9VZWtgQfn4p+UDVM2eDVkMZT1I6syp0YKxW2F9v+0pbRZLsvskhQv/vMb6ZfCay81GHbz5SHg==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
-      "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ==",
+      "version": "18.8.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
+      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz",
-      "integrity": "sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.0.tgz",
+      "integrity": "sha512-FIBZgS3DVJgqPwJzvZTuH4HNsZhHMa9SjxTKAZTlMsPw/UzpEjcf9f4dfgDJEHjK+HboUJo123Eshl6niwEm/Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/type-utils": "5.36.2",
-        "@typescript-eslint/utils": "5.36.2",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/type-utils": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
@@ -261,14 +250,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.2.tgz",
-      "integrity": "sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.0.tgz",
+      "integrity": "sha512-Ah5gqyX2ySkiuYeOIDg7ap51/b63QgWZA7w6AHtFrag7aH0lRQPbLzUjk0c9o5/KZ6JRkTTDKShL4AUrQa6/hw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/typescript-estree": "5.36.2",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -288,13 +277,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
-      "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.0.tgz",
+      "integrity": "sha512-d3nPmjUeZtEWRvyReMI4I1MwPGC63E8pDoHy0BnrYjnJgilBD3hv7XOiETKLY/zTwI7kCnBDf2vWTRUVpYw0Uw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/visitor-keys": "5.36.2"
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -305,13 +294,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz",
-      "integrity": "sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.0.tgz",
+      "integrity": "sha512-nfuSdKEZY2TpnPz5covjJqav+g5qeBqwSHKBvz7Vm1SAfy93SwKk/JeSTymruDGItTwNijSsno5LhOHRS1pcfw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.36.2",
-        "@typescript-eslint/utils": "5.36.2",
+        "@typescript-eslint/typescript-estree": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -332,9 +321,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
-      "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.0.tgz",
+      "integrity": "sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -345,13 +334,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
-      "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz",
+      "integrity": "sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/visitor-keys": "5.36.2",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -372,17 +361,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.36.2.tgz",
-      "integrity": "sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.0.tgz",
+      "integrity": "sha512-MO0y3T5BQ5+tkkuYZJBjePewsY+cQnfkYeRqS6tPh28niiIwPnQ1t59CSRcs1ZwJJNOdWw7rv9pF8aP58IMihA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/typescript-estree": "5.36.2",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -396,12 +386,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
-      "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz",
+      "integrity": "sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/types": "5.40.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1275,10 +1265,13 @@
       }
     },
     "node_modules/defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/deps-sort": {
       "version": "2.0.1",
@@ -1419,22 +1412,22 @@
       "dev": true
     },
     "node_modules/es-abstract": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
-      "integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
+      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
+        "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
@@ -1444,6 +1437,7 @@
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
@@ -1494,14 +1488,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.1",
-        "@humanwhocodes/config-array": "^0.10.4",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.10.5",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -1518,7 +1511,6 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -1527,6 +1519,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -1732,9 +1725,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1907,12 +1900,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
-    },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -1947,9 +1934,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -2368,9 +2355,9 @@
       "dev": true
     },
     "node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -2607,6 +2594,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
     "node_modules/js-yaml": {
@@ -2857,10 +2850,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -3604,6 +3600,20 @@
         }
       ]
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3611,9 +3621,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4129,9 +4139,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4435,9 +4445,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -4452,21 +4462,15 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.4"
       }
-    },
-    "@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-      "dev": true
     },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
@@ -4574,28 +4578,27 @@
       }
     },
     "@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-rADY+HtTOA52l9VZWtgQfn4p+UDVM2eDVkMZT1I6syp0YKxW2F9v+0pbRZLsvskhQv/vMb6ZfCay81GHbz5SHg==",
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
-      "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ==",
+      "version": "18.8.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
+      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz",
-      "integrity": "sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.0.tgz",
+      "integrity": "sha512-FIBZgS3DVJgqPwJzvZTuH4HNsZhHMa9SjxTKAZTlMsPw/UzpEjcf9f4dfgDJEHjK+HboUJo123Eshl6niwEm/Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/type-utils": "5.36.2",
-        "@typescript-eslint/utils": "5.36.2",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/type-utils": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
@@ -4603,53 +4606,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.2.tgz",
-      "integrity": "sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.0.tgz",
+      "integrity": "sha512-Ah5gqyX2ySkiuYeOIDg7ap51/b63QgWZA7w6AHtFrag7aH0lRQPbLzUjk0c9o5/KZ6JRkTTDKShL4AUrQa6/hw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/typescript-estree": "5.36.2",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
-      "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.0.tgz",
+      "integrity": "sha512-d3nPmjUeZtEWRvyReMI4I1MwPGC63E8pDoHy0BnrYjnJgilBD3hv7XOiETKLY/zTwI7kCnBDf2vWTRUVpYw0Uw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/visitor-keys": "5.36.2"
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz",
-      "integrity": "sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.0.tgz",
+      "integrity": "sha512-nfuSdKEZY2TpnPz5covjJqav+g5qeBqwSHKBvz7Vm1SAfy93SwKk/JeSTymruDGItTwNijSsno5LhOHRS1pcfw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.36.2",
-        "@typescript-eslint/utils": "5.36.2",
+        "@typescript-eslint/typescript-estree": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
-      "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.0.tgz",
+      "integrity": "sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
-      "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz",
+      "integrity": "sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/visitor-keys": "5.36.2",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4658,26 +4661,27 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.36.2.tgz",
-      "integrity": "sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.0.tgz",
+      "integrity": "sha512-MO0y3T5BQ5+tkkuYZJBjePewsY+cQnfkYeRqS6tPh28niiIwPnQ1t59CSRcs1ZwJJNOdWw7rv9pF8aP58IMihA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.36.2",
-        "@typescript-eslint/types": "5.36.2",
-        "@typescript-eslint/typescript-estree": "5.36.2",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.36.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
-      "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz",
+      "integrity": "sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/types": "5.40.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -5403,9 +5407,9 @@
       }
     },
     "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
       "dev": true
     },
     "deps-sort": {
@@ -5529,22 +5533,22 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.2.tgz",
-      "integrity": "sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
+      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
+        "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
@@ -5554,6 +5558,7 @@
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
         "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
@@ -5583,14 +5588,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.1",
-        "@humanwhocodes/config-array": "^0.10.4",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.10.5",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -5607,7 +5611,6 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -5616,6 +5619,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -5767,9 +5771,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5907,12 +5911,6 @@
         "functions-have-names": "^1.2.2"
       }
     },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
-    },
     "functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -5938,9 +5936,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -6245,9 +6243,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true
     },
     "is-core-module": {
@@ -6400,6 +6398,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
     "js-yaml": {
@@ -6605,9 +6609,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "mkdirp-classic": {
@@ -7161,6 +7165,17 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
+    "safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7168,9 +7183,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -7557,9 +7572,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "umd": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,9 +212,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.8.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
-      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
+      "version": "18.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+      "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -401,12 +401,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
-    },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.8.0",
@@ -2865,12 +2859,11 @@
       "dev": true
     },
     "node_modules/mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.1.0.tgz",
+      "integrity": "sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==",
       "dev": true,
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
@@ -4229,16 +4222,15 @@
       "dev": true
     },
     "node_modules/util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },
@@ -4587,9 +4579,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.8.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
-      "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
+      "version": "18.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+      "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -4687,12 +4679,6 @@
         "@typescript-eslint/types": "5.40.0",
         "eslint-visitor-keys": "^3.3.0"
       }
-    },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
     },
     "acorn": {
       "version": "8.8.0",
@@ -6624,12 +6610,11 @@
       "dev": true
     },
     "mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.1.0.tgz",
+      "integrity": "sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==",
       "dev": true,
       "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
@@ -7647,16 +7632,15 @@
       }
     },
     "util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feistel-cipher",
-  "version": "1.3.14",
+  "version": "1.4.0",
   "description": "Feistel cipher implementation for format-preserving encryption",
   "main": "dist/lib/src/typescript/index.js",
   "types": "dist/lib/src/typescript/index.d.ts",
@@ -36,20 +36,20 @@
   "devDependencies": {
     "@types/chai": "^4.3.3",
     "@types/keccak": "^3.0.1",
-    "@types/mocha": "^9.1.1",
-    "@types/node": "^18.7.15",
-    "@typescript-eslint/eslint-plugin": "^5.36.2",
-    "@typescript-eslint/parser": "^5.36.2",
+    "@types/mocha": "^10.0.0",
+    "@types/node": "^18.8.5",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
     "blakejs": "^1.2.1",
     "browserify": "17.0.0",
     "chai": "^4.3.6",
-    "eslint": "^8.23.0",
+    "eslint": "^8.25.0",
     "eslint-plugin-no-loops": "~0.3.0",
     "keccak": "^3.0.2",
     "mocha": "^10.0.0",
     "sha3": "^2.1.4",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.2"
+    "typescript": "^4.8.4"
   },
   "resolutions": {
     "websocket-extensions": "0.1.4"

--- a/test/src/typescript/browser.spec.ts
+++ b/test/src/typescript/browser.spec.ts
@@ -92,6 +92,9 @@ describe('FPECipher', () => {
 
       const smallNumber = cipher.encryptNumber(123)
       smallNumber.should.equal(24359)
+
+      const zero = cipher.encryptNumber(0)
+      zero.should.equal(0)
     })
   })
   describe('decrypt', () => {
@@ -120,7 +123,7 @@ describe('FPECipher', () => {
       smallNumber.should.equal(123)
 
       const zero = cipher.decryptNumber(0)
-      zero.should.equal(24402)
+      zero.should.equal(0)
     })
   })
 })

--- a/test/src/typescript/browser.spec.ts
+++ b/test/src/typescript/browser.spec.ts
@@ -109,6 +109,20 @@ describe('FPECipher', () => {
       found.should.equal(expected)
     })
   })
+  describe('decryptNumber', () => {
+    it('should return the right number', () => {
+      const expected = 123456789
+      const cipher = new feistel.FPECipher(SHA_256, 'some-32-byte-long-key-to-be-safe', 128)
+      const found = cipher.decryptNumber(22780178)
+      found.should.equal(expected)
+
+      const smallNumber = cipher.decryptNumber(24359)
+      smallNumber.should.equal(123)
+
+      const zero = cipher.decryptNumber(0)
+      zero.should.equal(24402)
+    })
+  })
 })
 describe('hash', () => {
   describe('H', () => {

--- a/test/src/typescript/browser.spec.ts
+++ b/test/src/typescript/browser.spec.ts
@@ -2,8 +2,10 @@ import * as feistel from '../../../lib/src/typescript/index'
 import {
   base256CharAt, hex2Readable, indexOfBase256, readable2Buffer, readable2Hex, toBase256Readable
 } from '../../../lib/src/typescript/index'
+import { extractBytes, splitBytes } from '../../../lib/src/typescript/utils/bytes'
 import { BLAKE2b, H, KECCAK, SHA_256, SHA_3 } from '../../../lib/src/typescript/utils/hash'
-import { split } from '../../../lib/src/typescript/utils/strings'
+import { extract, split } from '../../../lib/src/typescript/utils/strings'
+import { xor, xorBytes } from '../../../lib/src/typescript/utils/xor'
 
 describe('Cipher', () => {
   describe('encrypt', () => {
@@ -81,6 +83,14 @@ describe('FPECipher', () => {
       found.should.equal(expected)
     })
   })
+  describe('encryptNumber', () => {
+    it('should produce the right number', () => {
+      const expected = 22780178
+      const cipher = new feistel.FPECipher(SHA_256, 'some-32-byte-long-key-to-be-safe', 128)
+      const found = cipher.encryptNumber(123456789)
+      found.should.equal(expected)
+    })
+  })
   describe('decrypt', () => {
     it('should be deterministic', () => {
       const nonFPE = 'Edgewhere'
@@ -122,7 +132,48 @@ describe('hash', () => {
     })
   })
 })
+describe('bytes', () => {
+  describe('extractBytes', () => {
+    it('should return the appropriate byte array with the right length', () => {
+      const input = Buffer.from('abcd1234', 'binary')
+      let expected = Buffer.from('1234', 'binary')
+      let found = extractBytes(input, 4, 4)
+      found.should.eqls(expected)
+
+      expected = Buffer.from('1234abcd12', 'binary')
+      found = extractBytes(input, 4, 10)
+      found.should.eqls(expected)
+    })
+  })
+  describe('splitBytes', () => {
+    it('should split a byte array in two, the first part being the smallest if it is of odd length', () => {
+      const odd = Buffer.from([1, 2, 3, 4, 5])
+      let parts = splitBytes(odd)
+      parts.should.have.lengthOf(2)
+      parts[0].should.eqls(Buffer.from([1, 2]))
+      parts[1].should.eqls(Buffer.from([3, 4, 5]))
+
+      const even = Buffer.from([1, 2, 3, 4, 5, 6])
+      parts = splitBytes(even)
+      parts.should.have.lengthOf(2)
+      parts[0].should.eqls(Buffer.from([1, 2, 3]))
+      parts[1].should.eqls(Buffer.from([4, 5, 6]))
+    })
+  })
+})
 describe('strings', () => {
+  describe('extract', () => {
+    it('should return the appropriate string with the right length', () => {
+      const input = 'abcd1234'
+      let expected = '1234'
+      let found = extract(input, 4, 4)
+      found.should.equal(expected)
+
+      expected = '1234abcd12'
+      found = extract(input, 4, 10)
+      found.should.equal(expected)
+    })
+  })
   describe('split', () => {
     it('should split a string in two, the first part being the smallest if it is of odd length', () => {
       const odd = 'Edgewhere'
@@ -154,5 +205,21 @@ describe('Readable', () => {
     readable2Hex(found).should.equal('2a5d07024f5a501409')
     const hex = hex2Readable('2a5d07024f5a501409')
     hex.should.equal(found)
+  })
+})
+describe('XOR', () => {
+  describe('xor', () => {
+    it('should apply XOR operation to two strings appropriately', () => {
+      const expected = 'PPPP'
+      const found = xor('1234', 'abcd')
+      found.should.equal(expected)
+    })
+  })
+  describe('xorBytes', () => {
+    it('should apply XOR operation to two byte arrays appropriately', () => {
+      const expected = Buffer.from('PPPP', 'binary')
+      const found = xorBytes(Buffer.from('1234', 'binary'), Buffer.from('abcd', 'binary'))
+      found.should.eqls(expected)
+    })
   })
 })

--- a/test/src/typescript/browser.spec.ts
+++ b/test/src/typescript/browser.spec.ts
@@ -89,6 +89,9 @@ describe('FPECipher', () => {
       const cipher = new feistel.FPECipher(SHA_256, 'some-32-byte-long-key-to-be-safe', 128)
       const found = cipher.encryptNumber(123456789)
       found.should.equal(expected)
+
+      const smallNumber = cipher.encryptNumber(123)
+      smallNumber.should.equal(24359)
     })
   })
   describe('decrypt', () => {

--- a/test/src/typescript/node.spec.ts
+++ b/test/src/typescript/node.spec.ts
@@ -98,7 +98,7 @@ describe('FPECipher', () => {
       smallNumber.should.equal(24359)
 
       const zero = cipher.encryptNumber(0)
-      zero.should.equal(1028)
+      zero.should.equal(0)
     })
   })
   describe('decrypt', () => {
@@ -127,7 +127,7 @@ describe('FPECipher', () => {
       smallNumber.should.equal(123)
 
       const zero = cipher.decryptNumber(0)
-      zero.should.equal(24402)
+      zero.should.equal(0)
     })
   })
 })

--- a/test/src/typescript/node.spec.ts
+++ b/test/src/typescript/node.spec.ts
@@ -87,6 +87,14 @@ describe('FPECipher', () => {
       found.should.equal(expected)
     })
   })
+  describe('encryptNumber', () => {
+    it('should produce the right number', () => {
+      const expected = 22780178
+      const cipher = new feistel.FPECipher(SHA_256, 'some-32-byte-long-key-to-be-safe', 128)
+      const found = cipher.encryptNumber(123456789)
+      found.should.equal(expected)
+    })
+  })
   describe('decrypt', () => {
     it('should be deterministic', () => {
       const nonFPE = 'Edgewhere'

--- a/test/src/typescript/node.spec.ts
+++ b/test/src/typescript/node.spec.ts
@@ -136,19 +136,7 @@ describe('hash', () => {
     })
   })
 })
-describe('strings', () => {
-  describe('extract', () => {
-    it('should return the appropriate string with the right length', () => {
-      const input = 'abcd1234'
-      let expected = '1234'
-      let found = extract(input, 4, 4)
-      found.should.equal(expected)
-
-      expected = '1234abcd12'
-      found = extract(input, 4, 10)
-      found.should.equal(expected)
-    })
-  })
+describe('bytes', () => {
   describe('extractBytes', () => {
     it('should return the appropriate byte array with the right length', () => {
       const input = Buffer.from('abcd1234', 'binary')
@@ -159,21 +147,6 @@ describe('strings', () => {
       expected = Buffer.from('1234abcd12', 'binary')
       found = extractBytes(input, 4, 10)
       found.should.eqls(expected)
-    })
-  })
-  describe('split', () => {
-    it('should split a string in two, the first part being the smallest if it is of odd length', () => {
-      const odd = 'Edgewhere'
-      let parts = split(odd)
-      parts.should.have.lengthOf(2)
-      parts[0].should.equal('Edge')
-      parts[1].should.equal('where')
-
-      const even = 'cyrildever'
-      parts = split(even)
-      parts.should.have.lengthOf(2)
-      parts[0].should.equal('cyril')
-      parts[1].should.equal('dever')
     })
   })
   describe('splitBytes', () => {
@@ -189,6 +162,35 @@ describe('strings', () => {
       parts.should.have.lengthOf(2)
       parts[0].should.eqls(Buffer.from([1, 2, 3]))
       parts[1].should.eqls(Buffer.from([4, 5, 6]))
+    })
+  })
+})
+describe('strings', () => {
+  describe('extract', () => {
+    it('should return the appropriate string with the right length', () => {
+      const input = 'abcd1234'
+      let expected = '1234'
+      let found = extract(input, 4, 4)
+      found.should.equal(expected)
+
+      expected = '1234abcd12'
+      found = extract(input, 4, 10)
+      found.should.equal(expected)
+    })
+  })
+  describe('split', () => {
+    it('should split a string in two, the first part being the smallest if it is of odd length', () => {
+      const odd = 'Edgewhere'
+      let parts = split(odd)
+      parts.should.have.lengthOf(2)
+      parts[0].should.equal('Edge')
+      parts[1].should.equal('where')
+
+      const even = 'cyrildever'
+      parts = split(even)
+      parts.should.have.lengthOf(2)
+      parts[0].should.equal('cyril')
+      parts[1].should.equal('dever')
     })
   })
 })

--- a/test/src/typescript/node.spec.ts
+++ b/test/src/typescript/node.spec.ts
@@ -6,8 +6,10 @@ import * as feistel from '../../../lib/src/typescript/index'
 import {
   base256CharAt, hex2Readable, indexOfBase256, readable2Buffer, readable2Hex, toBase256Readable
 } from '../../../lib/src/typescript/index'
+import { extractBytes, splitBytes } from '../../../lib/src/typescript/utils/bytes'
 import { BLAKE2b, H, KECCAK, SHA_256, SHA_3 } from '../../../lib/src/typescript/utils/hash'
-import { split } from '../../../lib/src/typescript/utils/strings'
+import { extract, split } from '../../../lib/src/typescript/utils/strings'
+import { xor, xorBytes } from '../../../lib/src/typescript/utils/xor'
 
 describe('Cipher', () => {
   describe('encrypt', () => {
@@ -127,6 +129,30 @@ describe('hash', () => {
   })
 })
 describe('strings', () => {
+  describe('extract', () => {
+    it('should return the appropriate string with the right length', () => {
+      const input = 'abcd1234'
+      let expected = '1234'
+      let found = extract(input, 4, 4)
+      found.should.equal(expected)
+
+      expected = '1234abcd12'
+      found = extract(input, 4, 10)
+      found.should.equal(expected)
+    })
+  })
+  describe('extractBytes', () => {
+    it('should return the appropriate byte array with the right length', () => {
+      const input = Buffer.from('abcd1234', 'binary')
+      let expected = Buffer.from('1234', 'binary')
+      let found = extractBytes(input, 4, 4)
+      found.should.eqls(expected)
+
+      expected = Buffer.from('1234abcd12', 'binary')
+      found = extractBytes(input, 4, 10)
+      found.should.eqls(expected)
+    })
+  })
   describe('split', () => {
     it('should split a string in two, the first part being the smallest if it is of odd length', () => {
       const odd = 'Edgewhere'
@@ -140,6 +166,21 @@ describe('strings', () => {
       parts.should.have.lengthOf(2)
       parts[0].should.equal('cyril')
       parts[1].should.equal('dever')
+    })
+  })
+  describe('splitBytes', () => {
+    it('should split a byte array in two, the first part being the smallest if it is of odd length', () => {
+      const odd = Buffer.from([1, 2, 3, 4, 5])
+      let parts = splitBytes(odd)
+      parts.should.have.lengthOf(2)
+      parts[0].should.eqls(Buffer.from([1, 2]))
+      parts[1].should.eqls(Buffer.from([3, 4, 5]))
+
+      const even = Buffer.from([1, 2, 3, 4, 5, 6])
+      parts = splitBytes(even)
+      parts.should.have.lengthOf(2)
+      parts[0].should.eqls(Buffer.from([1, 2, 3]))
+      parts[1].should.eqls(Buffer.from([4, 5, 6]))
     })
   })
 })
@@ -158,5 +199,21 @@ describe('Readable', () => {
     readable2Hex(found).should.equal('2a5d07024f5a501409')
     const hex = hex2Readable('2a5d07024f5a501409')
     hex.should.equal(found)
+  })
+})
+describe('XOR', () => {
+  describe('xor', () => {
+    it('should apply XOR operation to two strings appropriately', () => {
+      const expected = 'PPPP'
+      const found = xor('1234', 'abcd')
+      found.should.equal(expected)
+    })
+  })
+  describe('xorBytes', () => {
+    it('should apply XOR operation to two byte arrays appropriately', () => {
+      const expected = Buffer.from('PPPP', 'binary')
+      const found = xorBytes(Buffer.from('1234', 'binary'), Buffer.from('abcd', 'binary'))
+      found.should.eqls(expected)
+    })
   })
 })

--- a/test/src/typescript/node.spec.ts
+++ b/test/src/typescript/node.spec.ts
@@ -93,6 +93,9 @@ describe('FPECipher', () => {
       const cipher = new feistel.FPECipher(SHA_256, 'some-32-byte-long-key-to-be-safe', 128)
       const found = cipher.encryptNumber(123456789)
       found.should.equal(expected)
+
+      const smallNumber = cipher.encryptNumber(123)
+      smallNumber.should.equal(24359)
     })
   })
   describe('decrypt', () => {

--- a/test/src/typescript/node.spec.ts
+++ b/test/src/typescript/node.spec.ts
@@ -96,6 +96,9 @@ describe('FPECipher', () => {
 
       const smallNumber = cipher.encryptNumber(123)
       smallNumber.should.equal(24359)
+
+      const zero = cipher.encryptNumber(0)
+      zero.should.equal(1028)
     })
   })
   describe('decrypt', () => {
@@ -111,6 +114,20 @@ describe('FPECipher', () => {
 
       found = cipher.decrypt('K¡(#q|r5*')
       found.should.equal(expected)
+    })
+  })
+  describe('decryptNumber', () => {
+    it('should return the right number', () => {
+      const expected = 123456789
+      const cipher = new feistel.FPECipher(SHA_256, 'some-32-byte-long-key-to-be-safe', 128)
+      const found = cipher.decryptNumber(22780178)
+      found.should.equal(expected)
+
+      const smallNumber = cipher.decryptNumber(24359)
+      smallNumber.should.equal(123)
+
+      const zero = cipher.decryptNumber(0)
+      zero.should.equal(24402)
     })
   })
 })


### PR DESCRIPTION
I mainly use this library to manipulate text files, ie. strings. But, because the "Format" word in the FPE acronym could have different meanings, I've implemented an extra feature for the FPECipher: the possibility to preserve the visible format when the input is a number, ie. if you use a 9-digit number, you could get a 9-digit number from the EncryptNumber() method.

IMPORTANT: Due to the way the Feistel cipher operates, numbers below 256 (ie. only one-byte long) can't preserve the length when using the EncryptNumber() method. If length matters, consider using EncryptString() instead.